### PR TITLE
[#76] Turn on mapbox-gl-rtl-text when RTL text is detected

### DIFF
--- a/src/visual.ts
+++ b/src/visual.ts
@@ -427,7 +427,12 @@ export class MapboxMap implements IVisual {
             // @ts-ignore
             mapboxgl.accessToken = this.settings.api.accessToken;
         }
-
+        
+        mapboxgl.setRTLTextPlugin(
+            'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js',
+            null,
+            true // Lazy load the plugin
+        );
 
         let style = this.settings.api.style == 'custom' ? this.settings.api.styleUrl : this.settings.api.style;
         if (this.mapStyle == '' || this.mapStyle != style) {


### PR DESCRIPTION
More info: https://docs.mapbox.com/mapbox-gl-js/example/mapbox-gl-rtl-text/

Resolves #76 

<img width="283" alt="Screenshot 2023-09-27 at 12 13 30" src="https://github.com/starschema/mapboxgl-powerbi/assets/33528704/bcf45935-321b-466e-aa99-b69d03a137b2">
