### PR TITLE
Default Color is missing if more than 5 data points are available

### DIFF
--- a/src/layers/circle.ts
+++ b/src/layers/circle.ts
@@ -200,7 +200,7 @@ export class Circle extends Layer {
 
         // Add transparent as default so that we only see regions
         // for which we have data values
-        categoricalStyle = categoricalStyle.concat(Array(this.requiredNumberOfParamsInCircleColor - categoricalStyle.length).fill('rgba(255,0,0,255)'));
+        categoricalStyle = categoricalStyle.concat(Array(Math.max(1, this.requiredNumberOfParamsInCircleColor - categoricalStyle.length)).fill('rgba(255,0,0,255)'));
 
         return categoricalStyle;
     }


### PR DESCRIPTION
In the `Circle.getColorStyle` function it's possible that there are more data colors than the minimum necessary values, then the code would create an array with a negative item number, leading to an exception.
The [match](https://docs.mapbox.com/style-spec/reference/expressions/#match) interpolate color is used for [circle-color](https://docs.mapbox.com/style-spec/reference/layers/#paint-circle-circle-color), and it requires at least one fallback value.