### PR TITLE
Map style select bug fix

### DIFF
--- a/src/visual.ts
+++ b/src/visual.ts
@@ -235,6 +235,12 @@ export class MapboxMap implements IVisual {
         this.drawControl.updateDrawTools(this.settings.api.lasso, this.settings.api.polygon);
         this.drawControl.manageHandlers(this);
         this.handleContextMenu();
+
+        mapboxgl.setRTLTextPlugin(
+            'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js',
+            null,
+            true // Lazy load the plugin
+        );
     }
 
     private removeMap() {
@@ -439,12 +445,6 @@ export class MapboxMap implements IVisual {
             // @ts-ignore
             mapboxgl.accessToken = this.settings.api.accessToken;
         }
-
-        mapboxgl.setRTLTextPlugin(
-            'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js',
-            null,
-            true // Lazy load the plugin
-        );
 
         let style = this.settings.api.style == 'custom' ? this.settings.api.styleUrl : this.settings.api.style;
         if (this.mapStyle == '' || this.mapStyle != style) {


### PR DESCRIPTION
**setRTLTextPlugin** was blocking the update function and because of this, map styles wouldn't update.
Moved the the plugin initialization to the and of the **addMap** function because it doesn't need to called several times and won't block anything there.